### PR TITLE
resizeImage now also returns query params

### DIFF
--- a/jquery.api.js
+++ b/jquery.api.js
@@ -91,10 +91,18 @@ Shopify.formatMoney = function(cents, format) {
 
 Shopify.resizeImage = function(image, size) {
   try {
-    if(size == 'original') { return image; }
-    else {      
-      var matches = image.match(/(.*\/[\w\-\_\.]+)\.(\w{2,4})/);
-      return matches[1] + '_' + size + '.' + matches[2];
+    if (size == 'original') { return image; }
+    else {
+      var output;
+      var matches = image.match(/(.*\/[\w\-\_\.]+)\.(\w{2,4})(.*)/);
+      
+      output = matches[1] + '_' + size + '.' + matches[2];
+
+      if (matches[3]) {
+        output.contact(matches[3]);
+      }
+
+      return output;
     }    
   } catch (e) { return image; }
 };


### PR DESCRIPTION
This will improve load time if the image already was loaded in the DOM with the query params. Which is the common case.

This will keep the image URL consistent.